### PR TITLE
Fix epoxy_extension_in_string when extension_list is null

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -360,7 +360,12 @@ bool
 epoxy_extension_in_string(const char *extension_list, const char *ext)
 {
     const char *ptr = extension_list;
-    size_t len = strlen(ext);
+    size_t len;
+     
+     if (!extension_list)
+        return false;
+        
+    len = strlen(ext);    
 
     /* Make sure that don't just find an extension with our name as a prefix. */
     while (true) {


### PR DESCRIPTION
For some X server not supporting any OpenGL feature, glXQueryExtensionsString 
will return NULL and causes the function to fail.

This was verified running an application on macOS while the X server was running
on Windows Xming 7.5.0.10
