### PR TITLE
nVidia glx.h uses __glx_h__; define that too.

### DIFF
--- a/include/epoxy/glx.h
+++ b/include/epoxy/glx.h
@@ -30,11 +30,12 @@
 #ifndef EPOXY_GLX_H
 #define EPOXY_GLX_H
 
-#if defined(GLX_H) || defined(__glxext_h_)
+#if defined(GLX_H) || defined(__glx_h__) || defined(__glxext_h_)
 #error "epoxy/glx.h" must be included before (or in place of) "GL/glx.h".
 #endif
 
 #define GLX_H
+#define __glx_h__
 #define __glxext_h_
 
 #include "epoxy/gl.h"


### PR DESCRIPTION
The code used to check this symbol, but commit 689abf4 replaced it with
GLX_H, presumably to work better with either Mesa or Khronos headers.
But nVidia's header use the older include guard. Add it as another
option.

Should fix the headerguards.c compile test when the system glx.h is from
nVidia's binary drivers.
